### PR TITLE
fix: add extra dependencies for 2021.x-linux-il2cpp (lld)

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -129,3 +129,13 @@ RUN [ `echo $version | grep -v '^2019.1.'` ] && exit 0 || : \
     libssl1.0  \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+#=======================================================================================
+# [2021.x-linux-il2cpp] lld
+#=======================================================================================
+RUN [ `echo $version-$module | grep -v '^2021.*-linux-il2cpp'` ] && exit 0 || : \
+  && apt-get -q update \
+  && apt-get -q install -y --no-install-recommends --allow-downgrades \
+    lld \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
#### Changes

- When I start a Unity project with `2021.1.0b3-linux-il2cpp`, it exits with compilation errors.
  - `clang: error: invalid linker name in argument '-fuse-ld=lld'`
- Add dependencies for `2021.1.x-linux-il2cpp`
  - lld
 
#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)

#### Versions and modules to be fixed

Tested in my repo.

Before: https://github.com/mob-sakai/docker/actions/runs/512353839
After: https://github.com/mob-sakai/docker/actions/runs/512671748

| Version    | base | linux<br>-il2cpp | windows<br>-mono | mac<br>-mono | android | ios | webgl |
| ---------- | ---- | ---------------- | ---------------- | ------------ | ------- | --- | ----- |
| 2020.1.17f1 | ✅    | ✅            | ✅                | ✅            | ✅       | ✅   | ✅     |
| 2020.2.2f1 | ✅    | ✅            | ✅                | ✅            | ✅       | ✅   | ✅     |
| 2021.1.0b3 | ✅    | ❌ ->✅            | ✅                | ✅            | ✅       | ✅   | ✅     |