### PR TITLE
fix: building for mac-mono in 2021.2.0b/2022.1.0a failed

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -242,3 +242,12 @@ RUN echo "$version-$module" | grep -q -v '^2021.*linux-il2cpp' \
     lld \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+#=======================================================================================
+# [2021.2/2022.1-mac-mono] MacStandaloneSupport variation paths (arm64 -> ARM64)
+#=======================================================================================
+RUN echo "$version-$module" | grep -q -v '^\(2021.2\|2022.1\).*mac-mono' \
+  && exit 0 \
+  || : \
+  && cd /opt/unity/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations \
+  && ls | grep arm64 | sed 'p;s/arm64/ARM64/' | xargs -n2 mv


### PR DESCRIPTION
#### Changes

- Change the path `arm64` to `ARM64`

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)

#### Information

**NOTE: This bug may have been fixed in the release version (f).**

```
Building /github/workspace/build/StandaloneOSX/StandaloneOSX.app/Contents/Frameworks/libmonobdwgc-2.0.dylib failed with output:
The properties of source file /opt/unity/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations/macos_x64ARM64_player_nondevelopment_mono/UnityPlayer.app/Contents/Frameworks/libmonobdwgc-2.0.dylib could not be retrieved: No such file or directory
```
- Rename `macos_x64arm64_player_nondevelopment_mono` directory to`macos_x64ARM64_player_nondevelopment_mono` to fix.
- In Linux, file/directory name is case-sensitive.
- There are other similar bugs depending on the platform.

```
docker run -it mobsakai/unity_editor:2022.1.0a12-mac-mono ls -1 /opt/unity/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations
macos_arm64_player_development_mono
macos_arm64_player_nondevelopment_mono
macos_arm64_server_development_mono
macos_arm64_server_nondevelopment_mono
macos_x64_player_development_mono
macos_x64_player_nondevelopment_mono
macos_x64_server_development_mono
macos_x64_server_nondevelopment_mono
macos_x64arm64_player_development_mono
macos_x64arm64_player_nondevelopment_mono
macos_x64arm64_server_development_mono
macos_x64arm64_server_nondevelopment_mono
mono
```

BTW, in `2021.1.9f1-mac-mono`, no problem.
```
docker run -it mobsakai/unity_editor:2021.1.9f1-mac-mono ls -1 /opt/unity/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations
macos_arm64_development_mono
macos_arm64_nondevelopment_mono
macos_x64_development_mono
macos_x64_nondevelopment_mono
macos_x64arm64_development_mono
macos_x64arm64_nondevelopment_mono
mono
```